### PR TITLE
Add header/footer to legal pages

### DIFF
--- a/html/legal/conditions-utilisation.html
+++ b/html/legal/conditions-utilisation.html
@@ -7,6 +7,9 @@
   </head>
 
   <body>
+    <!-- Header dynamique -->
+    <div id="header"></div>
+
     <h1>Conditions d'utilisation</h1>
 
     <p>En naviguant sur ce site, vous acceptez les conditions ci-dessous :</p>
@@ -41,5 +44,13 @@
       Le site est fourni à titre informatif. Lum&Sens ne peut être tenu
       responsable des erreurs ou des interruptions de service.
     </p>
+
+    <!-- Footer dynamique -->
+    <div id="footer"></div>
+
+    <!-- Scripts avec defer pour optimiser le rendu -->
+    <script src="../../assets/js/header-scroll.js" defer></script>
+    <script src="../../assets/js/menu-burger.js" defer></script>
+    <script src="../../assets/js/layout.js" defer></script>
   </body>
 </html>

--- a/html/legal/mentions-legales.html
+++ b/html/legal/mentions-legales.html
@@ -6,6 +6,9 @@
     <title>Document</title>
   </head>
   <body>
+    <!-- Header dynamique -->
+    <div id="header"></div>
+
     <h1>Mentions légales</h1>
 
     <p>
@@ -34,5 +37,13 @@
       <strong>Contact :</strong><br />
       Pour toute question, veuillez nous écrire à : à venir
     </p>
+
+    <!-- Footer dynamique -->
+    <div id="footer"></div>
+
+    <!-- Scripts avec defer pour optimiser le rendu -->
+    <script src="../../assets/js/header-scroll.js" defer></script>
+    <script src="../../assets/js/menu-burger.js" defer></script>
+    <script src="../../assets/js/layout.js" defer></script>
   </body>
 </html>

--- a/html/legal/politique-confidentialite.html
+++ b/html/legal/politique-confidentialite.html
@@ -6,6 +6,9 @@
     <title>Document</title>
   </head>
   <body>
+    <!-- Header dynamique -->
+    <div id="header"></div>
+
     <h1>Politique de confidentialité</h1>
 
     <p>
@@ -25,5 +28,13 @@
       Vous pouvez nous contacter à tout moment pour demander la suppression de
       vos informations si vous nous les avez communiquées via un formulaire.
     </p>
+
+    <!-- Footer dynamique -->
+    <div id="footer"></div>
+
+    <!-- Scripts avec defer pour optimiser le rendu -->
+    <script src="../../assets/js/header-scroll.js" defer></script>
+    <script src="../../assets/js/menu-burger.js" defer></script>
+    <script src="../../assets/js/layout.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- load dynamic header and footer on legal pages
- include layout scripts for shared navigation and footer

## Testing
- `npm test` *(fails: could not find package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68469bc553288325bcc149ae950505b3