### PR TITLE
Fix lang attribute in legal pages

### DIFF
--- a/html/legal/conditions-utilisation.html
+++ b/html/legal/conditions-utilisation.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Conditions d'utilisation – Lum&Sens</title>
   </head>
 
   <body>

--- a/html/legal/mentions-legales.html
+++ b/html/legal/mentions-legales.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Mentions légales – Lum&Sens</title>
   </head>
   <body>
     <h1>Mentions légales</h1>

--- a/html/legal/politique-confidentialite.html
+++ b/html/legal/politique-confidentialite.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="fr">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Document</title>
+    <title>Politique de confidentialité – Lum&Sens</title>
   </head>
   <body>
     <h1>Politique de confidentialité</h1>


### PR DESCRIPTION
## Summary
- fix wrong `lang` attribute in legal pages
- set proper titles for legal pages

## Testing
- `npm test` *(fails: could not find `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684698e6b56083258057e2a2ec06138b